### PR TITLE
Return full metadata in callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ npm install name-to-imdb
 ## Example
 ```javascript
 var nameToImdb = require("name-to-imdb");
-nameToImdb({ name: "south park" }, function(err, res, inf) { 
+nameToImdb({ name: "south park" }, function(err, res, inf, full) { 
 	console.log(res); // prints "tt0121955"
 	console.log(inf); // inf contains info on where we matched that name - e.g. metadata, or on imdb
+	console.log(full) // an object with all the available metadata
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,29 @@ npm install name-to-imdb
 **args.providers** - an array of providers to search in; possible options are ``metadata`` and ``imdbFind``; default is ``["metadata", "imdbFind"]``
 
 ## Example
-```javascript
+```js
 var nameToImdb = require("name-to-imdb");
-nameToImdb({ name: "south park" }, function(err, res, inf, full) { 
-	console.log(res); // prints "tt0121955"
+nameToImdb({ name: "south park" }, function(err, res, inf) { 
+	console.log(res.id); // prints "tt0121955"
+	console.log(res.name); // prints "South Park"
 	console.log(inf); // inf contains info on where we matched that name - e.g. metadata, or on imdb
-	console.log(full) // an object with all the available metadata
 })
 ```
 
-
+```js
+// console.log({ res })
+res: {
+    id: 'tt0121955',
+    name: 'South Park',
+    year: 1997,
+    type: 'TV series',
+    yearRange: '1997-',
+    image: {
+      src: 'https://m.media-amazon.com/images/M/MV5BOGE2YWUzMDItNTg2Ny00NTUzLTlmZGYtNWMyNzVjMjQ3MThkXkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_.jpg',
+      width: 680,
+      height: 1000
+    },
+    starring: 'Trey Parker, Matt Stone',
+    similarity: 1
+  }
+```

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var CACHE_TTL = 12*60*60*1000; // if we don't find an item, how long does it sta
 var cache = { };
 var cacheLastSet = { };
 
-// Named queue, means that we're not working on one name more than once at a tim
+// Named queue, means that we're not working on one name more than once at a time
 // and a total of 3 names at once
 var queue = new namedQueue(worker, 3)
 
@@ -48,7 +48,7 @@ function nameToImdb(args, cb) {
         id: key,
         q: q,
         providers: args.providers || defaultProviders,
-    }, function(err, imdb_id, match) {
+    }, function(err, imdb_id, match, full) {
         if (err)
             return cb(err)
         
@@ -57,7 +57,7 @@ function nameToImdb(args, cb) {
             cacheLastSet[key] = Date.now()
         }
 
-        cb(null, imdb_id, match)
+        cb(null, imdb_id, match, full)
     })
 };
 
@@ -76,12 +76,12 @@ function worker(task, cb) {
         if (!provider)
             return cb(new Error('unknown provider: '+n))
 
-        provider(task.q, function(err, id) {
+        provider(task.q, function(err, id, match, res) {
             if (err)
                 return cb(err)
 
             if (id)
-                return cb(null, id, { match: n })
+                return cb(null, id, { match: n }, res)
             else
                 nextProv()
         })

--- a/index.js
+++ b/index.js
@@ -48,16 +48,16 @@ function nameToImdb(args, cb) {
         id: key,
         q: q,
         providers: args.providers || defaultProviders,
-    }, function(err, imdb_id, match, full) {
+    }, function(err, res, match) {
         if (err)
             return cb(err)
         
-        if (imdb_id) {
-            cache[key] = [imdb_id, match]
+        if (res.id) {
+            cache[key] = [res.id, match]
             cacheLastSet[key] = Date.now()
         }
 
-        cb(null, imdb_id, match, full)
+        cb(null, res, match)
     })
 };
 
@@ -76,12 +76,12 @@ function worker(task, cb) {
         if (!provider)
             return cb(new Error('unknown provider: '+n))
 
-        provider(task.q, function(err, id, match, res) {
+        provider(task.q, function(err, res) {
             if (err)
                 return cb(err)
 
-            if (id)
-                return cb(null, id, { match: n }, res)
+            if (res)
+                return cb(null, res, { match: n })
             else
                 nextProv()
         })

--- a/providers/imdbFind.js
+++ b/providers/imdbFind.js
@@ -40,7 +40,7 @@ function imdbFind(task, cb, loose) {
         if (results)
             matchSimilar(results, function(result) {
                 if (result)
-                    cb(null, result.id, { match: url })
+                    cb(null, result.id, { match: url }, result)
                 else
                     retry()
             })
@@ -62,7 +62,10 @@ function imdbFind(task, cb, loose) {
                 id: result.id,
                 name: result.l,
                 year: result.y,
-                type: result.q
+                type: result.q,
+                yearRange: result.yr,
+                images: result.i,
+                starring: result.s,
             }
 
             var movieMatch = task.type == 'movie' && res.type == 'feature'

--- a/providers/imdbFind.js
+++ b/providers/imdbFind.js
@@ -40,7 +40,7 @@ function imdbFind(task, cb, loose) {
         if (results)
             matchSimilar(results, function(result) {
                 if (result)
-                    cb(null, result.id, { match: url }, result)
+                    cb(null, result, { match: url })
                 else
                     retry()
             })
@@ -64,7 +64,11 @@ function imdbFind(task, cb, loose) {
                 year: result.y,
                 type: result.q,
                 yearRange: result.yr,
-                images: result.i,
+                image: result.i ? {
+                    src: result.i[0],
+                    width: result.i[1],
+                    height: result.i[2]
+                } : undefined,
                 starring: result.s,
             }
 


### PR DESCRIPTION
Opening the pull request to start a discussion.
I have added the full metadata to the `imdbFind` provider and tested some queries and they all worked.

Not sure how to test the `cinemeta` provider or the cache 🤔 

Also I used `full` as the object name but I'm down to change it to anything.

### Example Result:
```js
var nameToImdb = require("name-to-imdb");
nameToImdb({ name: "South Park" }, function (err, res, inf, full) {
  console.log(full)
})
```
```
{
  id: 'tt0121955',
  name: 'South Park',
  year: 1997,
  type: 'TV series',
  yearRange: '1997-',
  images: [
    'https://m.media-amazon.com/images/M/MV5BOGE2YWUzMDItNTg2Ny00NTUzLTlmZGYtNWMyNzVjMjQ3MThkXkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_.jpg', 
    680,
    1000
  ],
  starring: 'Trey Parker, Matt Stone',
  similarity: 1
}
```

Linked Issue: #8 