### PR TITLE
Add missing check for empty results

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function nameToImdb(args, cb) {
             cacheLastSet[key] = Date.now()
         }
 
-        cb(null, res.id, { ...match, meta: res })
+        cb(null, (res || {}).id, { ...match, meta: res })
     })
 };
 


### PR DESCRIPTION
When no matches are found the function throws an error instead of returning undefined