### PR TITLE
Make movieMatch and seriesMatch less strict

### DIFF
--- a/providers/imdbFind.js
+++ b/providers/imdbFind.js
@@ -71,9 +71,9 @@ function imdbFind(task, cb, loose) {
                 starring: result.s,
             }
 
-            var movieMatch = task.type == 'movie' && res.type == 'feature'
+            var movieMatch = task.type == 'movie' && /movie|feature/gi.test(res.type)
 
-            var seriesMatch = task.type == 'series' && ['TV series', 'TV mini-series'].indexOf(res.type) > -1
+            var seriesMatch = task.type == 'series' && /TV (mini-)?series/gi.test(res.type)
 
             if (!task.type || movieMatch || seriesMatch) {
 


### PR DESCRIPTION
I was unable to find https://www.imdb.com/title/tt0827737/ when searching for "Lupin first contact", "Lupin episode 0" or even when copy-pasting the full name.

I found out that it was not finding it because the type of this entry is `"TV movie"` and was failing the movieMatch check that was looking only for `"feature"`.

I think that every type that includes the word "movie" somewhere, should always be considered a movie.

## Without this fix:
```ts
nameToImdb({ name: 'Lupin first contact', type: 'movie' }, (e, r, i) => {
    console.log(i) // not found 😢😢😢
})
```

## With this fix:
```ts
nameToImdb({ name: 'Lupin first contact', type: 'movie' }, (e, r, i) => {
    console.log(i) // found!! 🎉🎉
})
```