### PR TITLE
sync version of nameToImdb()

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function nameToImdbSync(args) {
           cacheLastSet[key] = Date.now();
         }
   
-        resolve([(res || {}).id, { ...match, meta: res }]);
+        resolve({res:(res || {}).id, inf:{ ...match, meta: res }});
       });
     });
   };


### PR DESCRIPTION
nameToImdbSync() can be used for manually scraping websites for static addon catalogs. 
in my opinion, sync functions work better to avoid rate limits and easily incorporate waits.